### PR TITLE
issue #70: LongConverter.getS7Type() returns DWORD

### DIFF
--- a/src/main/java/com/github/s7connector/impl/serializer/converter/LongConverter.java
+++ b/src/main/java/com/github/s7connector/impl/serializer/converter/LongConverter.java
@@ -40,7 +40,7 @@ public final class LongConverter implements S7Serializable {
 	/** {@inheritDoc} */
 	@Override
 	public S7Type getS7Type() {
-		return S7Type.WORD;
+		return S7Type.DWORD;
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
fixes issue #70 by setting the return value of LongConverter.getS7Type() to DWORD