### PR TITLE
issue #76 set S7Type.DINT size to 4 Byte

### DIFF
--- a/src/main/java/com/github/s7connector/impl/utils/S7Type.java
+++ b/src/main/java/com/github/s7connector/impl/utils/S7Type.java
@@ -86,7 +86,7 @@ public enum S7Type {
 	/**
 	 * A DINT-type (same as DWORD-type)
 	 */
-	DINT(LongConverter.class, 2, 0);
+	DINT(LongConverter.class, 4, 0);
 
 	private int byteSize, bitSize;
 


### PR DESCRIPTION
fixes size of S7Type.DINT size as mentioned in issue #76 