### PR TITLE
#77 added INT data type

### DIFF
--- a/src/main/java/com/github/s7connector/impl/serializer/converter/ShortConverter.java
+++ b/src/main/java/com/github/s7connector/impl/serializer/converter/ShortConverter.java
@@ -1,0 +1,67 @@
+/*
+Copyright 2016 S7connector members (github.com/s7connector)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.github.s7connector.impl.serializer.converter;
+
+import com.github.s7connector.api.S7Serializable;
+import com.github.s7connector.impl.utils.S7Type;
+
+public class ShortConverter implements S7Serializable {
+
+	private static final short OFFSET_HIGH_BYTE = 0;
+	private static final short OFFSET_LOW_BYTE = 1;
+
+	/** {@inheritDoc} */
+	@Override
+	public <T> T extract(final Class<T> targetClass, final byte[] buffer, final int byteOffset, final int bitOffset) {
+		final byte lower = buffer[byteOffset + OFFSET_LOW_BYTE];
+		final byte higher = buffer[byteOffset + OFFSET_HIGH_BYTE];
+
+		final Integer i = (lower & 0xFF) | ((higher << 8) & 0xFF00);
+
+		return targetClass.cast(i.shortValue());
+		
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public S7Type getS7Type() {
+		return S7Type.INT;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public int getSizeInBits() {
+		return 0;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public int getSizeInBytes() {
+		return 2;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void insert(final Object javaType, final byte[] buffer, final int byteOffset, final int bitOffset,
+			final int size) {
+		final Short value = (Short) javaType;
+		final byte lower = (byte) ((value >> 0) & 0xFF);
+		final byte higher = (byte) ((value >> 8) & 0xFF);
+		buffer[byteOffset + OFFSET_LOW_BYTE] = lower;
+		buffer[byteOffset + OFFSET_HIGH_BYTE] = higher;
+	}
+
+}

--- a/src/main/java/com/github/s7connector/impl/utils/S7Type.java
+++ b/src/main/java/com/github/s7connector/impl/utils/S7Type.java
@@ -22,6 +22,7 @@ import com.github.s7connector.impl.serializer.converter.DateAndTimeConverter;
 import com.github.s7connector.impl.serializer.converter.DateConverter;
 import com.github.s7connector.impl.serializer.converter.IntegerConverter;
 import com.github.s7connector.impl.serializer.converter.LongConverter;
+import com.github.s7connector.impl.serializer.converter.ShortConverter;
 import com.github.s7connector.impl.serializer.converter.RealConverter;
 import com.github.s7connector.impl.serializer.converter.StringConverter;
 import com.github.s7connector.impl.serializer.converter.StructConverter;
@@ -86,7 +87,12 @@ public enum S7Type {
 	/**
 	 * A DINT-type (same as DWORD-type)
 	 */
-	DINT(LongConverter.class, 2, 0);
+	DINT(LongConverter.class, 4, 0),
+
+	/**
+	 * A INT-type
+	 */
+	INT(ShortConverter.class, 2, 0);
 
 	private int byteSize, bitSize;
 

--- a/src/test/java/com/github/s7connector/test/converter/ShortConverterTest.java
+++ b/src/test/java/com/github/s7connector/test/converter/ShortConverterTest.java
@@ -1,0 +1,77 @@
+/*
+Copyright 2016 S7connector members (github.com/s7connector)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.github.s7connector.test.converter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.github.s7connector.impl.serializer.converter.ShortConverter;
+
+public class ShortConverterTest
+{
+	@Test
+	public void insert1()
+	{
+		
+		ShortConverter c = new ShortConverter();
+		byte[] buffer = new byte[] { 0, 0, 0, 0 };
+		c.insert((short) 666, buffer, 0, 0, 2);
+		for (int i=0; i<buffer.length; i++)
+			System.out.print( Integer.toHexString(buffer[i] & 0xFF) + ",");
+		
+		Assert.assertEquals( 0x02, (byte)buffer[0]);
+		Assert.assertEquals( (byte)0x9a, (byte)buffer[1]);
+	}
+
+	@Test
+	public void insert2()
+	{
+		ShortConverter c = new ShortConverter();
+		byte[] buffer = new byte[] { 0, 0, 0, 0 };
+		c.insert((short)666, buffer, 1, 0, 2);
+		Assert.assertEquals( 0x00, (byte)buffer[0]);
+		Assert.assertEquals( 0x02, (byte)buffer[1]);
+		Assert.assertEquals( (byte)0x9a, (byte)buffer[2]);
+		Assert.assertEquals( 0x00, (byte)buffer[3]);
+	}
+
+	@Test
+	public void extract1()
+	{
+		ShortConverter c = new ShortConverter();
+		byte[] buffer = new byte[]{ 0x02, (byte)0x9a, 0, 0 };
+
+		for (int i=0; i<buffer.length; i++)
+			System.out.print( Integer.toHexString(buffer[i] & 0xFF) + ",");
+
+		int i = c.extract(Short.class, buffer, 0, 0);
+		Assert.assertEquals(666, i);
+	}
+	
+	@Test
+	public void extract2()
+	{
+		ShortConverter c = new ShortConverter();
+		byte[] buffer = new byte[]{ 0, 0, 0x02, (byte)0x9a, 0, 0 };
+
+		for (int i=0; i<buffer.length; i++)
+			System.out.print( Integer.toHexString(buffer[i] & 0xFF) + ",");
+
+		int i = c.extract(Short.class, buffer, 2, 0);
+		Assert.assertEquals(666, i);
+	}
+	
+}


### PR DESCRIPTION
added INT support for #77 and #76 . my local tests (without PLC) are


  | insert | extract
-- | -- | --
WORD | 0 | 0
WORD | 65.535 | 65.535
WORD | 65.536 | 0
WORD | -32.768 | 32.768
WORD | -32.769 | 32.767
WORD | 32.767 | 32.767
WORD | 32.768 | 32.768
INT | 32.767 | 32.767
INT | -32.768 | -32.768
INT | -32.769 | 32.767
INT | 32.768 | -32.768
DINT | -2.147.483.648 | -2.147.483.648
DINT | -2.147.483.649 | 2.147.483.647
DINT | 2.147.483.647 | 2.147.483.647
DINT | 2.147.483.648 | -2.147.483.648
DWORD | 0 | 0
DWORD | 4.294.967.296 | 0
DWORD | 4.294.967.295 | -1
DWORD | -2.147.483.647 | -2.147.483.647
DWORD | -2.147.483.648 | -2.147.483.648
DWORD | 2.147.483.647 | 2.147.483.647
DWORD | 2.147.483.648 | -2.147.483.648

