### PR TITLE
Fix #91: rack other than 0 does not work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Getting Started
             S7ConnectorFactory
             .buildTCPConnector()
             .withHost("10.0.0.220")
+            .withType(1) //optional
             .withRack(0) //optional
             .withSlot(2) //optional
             .build();

--- a/src/main/java/com/github/s7connector/api/factory/S7ConnectorFactory.java
+++ b/src/main/java/com/github/s7connector/api/factory/S7ConnectorFactory.java
@@ -35,7 +35,7 @@ public class S7ConnectorFactory {
 
         private SiemensPLCS plcsType;
 
-        private int rack = 0, slot = 2, port = 102, timeout = 2000;
+        private int type = 1, rack = 0, slot = 2, port = 102, timeout = 2000;
 
         TCPConnectionBuilder(SiemensPLCS type) {
             this.plcsType = type;
@@ -45,7 +45,7 @@ public class S7ConnectorFactory {
          * Builds a connection with given params
          */
         public S7Connector build() {
-            return new S7TCPConnection(this.host, this.rack, this.slot, this.port, this.timeout, this.plcsType);
+            return new S7TCPConnection(this.host, this.type, this.rack, this.slot, this.port, this.timeout, this.plcsType);
         }
 
         /**
@@ -61,6 +61,14 @@ public class S7ConnectorFactory {
          */
         public TCPConnectionBuilder withPort(final int port) {
             this.port = port;
+            return this;
+        }
+
+        /**
+         * use rack, default is 1
+         */
+        public TCPConnectionBuilder withType(final int type) {
+            this.type = type;
             return this;
         }
 

--- a/src/main/java/com/github/s7connector/impl/S7TCPConnection.java
+++ b/src/main/java/com/github/s7connector/impl/S7TCPConnection.java
@@ -54,6 +54,15 @@ public final class S7TCPConnection extends S7BaseConnection {
     private final int port;
 
     /**
+     * Connection type:
+     * 1 = PG
+     * 2 = OP
+     * 3 = S7 Basic
+     * 4-10 = Generic
+     */
+    private final int type;
+
+    /**
      * Rack and slot number
      */
     private final int rack, slot;
@@ -79,8 +88,9 @@ public final class S7TCPConnection extends S7BaseConnection {
      * @param host
      * @throws S7Exception
      */
-    public S7TCPConnection(final String host, final int rack, final int slot, final int port, final int timeout, final SiemensPLCS plcType) throws S7Exception {
+    public S7TCPConnection(final String host, final int type, final int rack, final int slot, final int port, final int timeout, final SiemensPLCS plcType) throws S7Exception {
         this.host = host;
+        this.type = type;
         this.rack = rack;
         this.slot = slot;
         this.port = port;
@@ -135,7 +145,7 @@ public final class S7TCPConnection extends S7BaseConnection {
                     DaveArea.LOCAL.getCode(), // TODO Local MPI-Address?
                     protocol);
 
-            this.dc = new TCPConnection(this.di, this.rack, this.slot);
+            this.dc = new TCPConnection(this.di, this.type, this.rack, this.slot);
             final int res = this.dc.connectPLC();
             checkResult(res);
 

--- a/src/main/java/com/github/s7connector/impl/nodave/TCPConnection.java
+++ b/src/main/java/com/github/s7connector/impl/nodave/TCPConnection.java
@@ -25,6 +25,11 @@ package com.github.s7connector.impl.nodave;
 public final class TCPConnection extends S7Connection {
 
     /**
+     * The connection type.
+     */
+    int type;
+
+    /**
      * The rack.
      */
     int rack;
@@ -41,8 +46,9 @@ public final class TCPConnection extends S7Connection {
      * @param rack the rack
      * @param slot the slot
      */
-    public TCPConnection(final PLCinterface ifa, final int rack, final int slot) {
+    public TCPConnection(final PLCinterface ifa, final int type, final int rack, final int slot) {
         super(ifa);
+        this.type = type;
         this.rack = rack;
         this.slot = slot;
         this.PDUstartIn = 7;
@@ -73,8 +79,8 @@ public final class TCPConnection extends S7Connection {
         			(byte) 0xC0, (byte) 0x01, (byte) 0x09
         	};
         	System.arraycopy(b4, 0, this.msgOut, 4, b4.length);
-            this.msgOut[17] = (byte) (this.rack + 1);
-            this.msgOut[18] = (byte) this.slot;
+            this.msgOut[17] = (byte) this.type;
+            this.msgOut[18] = (byte) ((16 * (this.rack *2) ) +this.slot);
             packetLength = b4.length;
         }
         this.sendISOPacket(packetLength);


### PR DESCRIPTION
Rack was setted in the first byte of [TSAP](url). That byte is reserved for the "Connection type".

I fix setting the rack in the second byte of the TSAP.

I add a type parameter(default 1) to the S7ConnectorFactory class:
```java
    //Create connection
    S7Connector connector = 
            S7ConnectorFactory
            .buildTCPConnector()
            .withHost("10.0.0.220")
            .withType(1) //optional
            .withRack(0) //optional
            .withSlot(2) //optional
            .build();
```

Then i set the rack in the second byte of the TSAP.
```java
    this.msgOut[17] = (byte) this.type;
    this.msgOut[18] = (byte) ((16 * (this.rack *2) ) +this.slot);
```