### PR TITLE
adding support for (de-)serializing array of STRUCT

### DIFF
--- a/src/main/java/com/github/s7connector/impl/serializer/S7SerializerImpl.java
+++ b/src/main/java/com/github/s7connector/impl/serializer/S7SerializerImpl.java
@@ -15,11 +15,6 @@ limitations under the License.
 */
 package com.github.s7connector.impl.serializer;
 
-import java.lang.reflect.Array;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.s7connector.api.DaveArea;
 import com.github.s7connector.api.S7Connector;
 import com.github.s7connector.api.S7Serializer;
@@ -27,165 +22,171 @@ import com.github.s7connector.exception.S7Exception;
 import com.github.s7connector.impl.serializer.parser.BeanEntry;
 import com.github.s7connector.impl.serializer.parser.BeanParseResult;
 import com.github.s7connector.impl.serializer.parser.BeanParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Array;
 
 /**
  * The Class S7Serializer is responsible for serializing S7 TCP Connection
  */
 public final class S7SerializerImpl implements S7Serializer {
 
-	/** Local Logger. */
-	private static final Logger logger = LoggerFactory.getLogger(S7SerializerImpl.class);
+    /**
+     * Local Logger.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(S7SerializerImpl.class);
 
-	/**
-	 * Extracts bytes from a buffer.
-	 *
-	 * @param <T>
-	 *            the generic type
-	 * @param beanClass
-	 *            the bean class
-	 * @param buffer
-	 *            the buffer
-	 * @param byteOffset
-	 *            the byte offset
-	 * @return the t
-	 */
-	public static <T> T extractBytes(final Class<T> beanClass, final byte[] buffer, final int byteOffset) {
-		logger.trace("Extracting type {} from buffer with size: {} at offset {}", beanClass.getName(), buffer.length,
-				byteOffset);
+    /**
+     * Extracts bytes from a buffer.
+     *
+     * @param <T>        the generic type
+     * @param beanClass  the bean class
+     * @param buffer     the buffer
+     * @param byteOffset the byte offset
+     * @return the t
+     */
+    public static <T> T extractBytes(final Class<T> beanClass, final byte[] buffer, final int byteOffset) {
+        logger.trace("Extracting type {} from buffer with size: {} at offset {}", beanClass.getName(), buffer.length,
+                byteOffset);
 
-		try {
-			final T obj = beanClass.newInstance();
-			final BeanParseResult result = BeanParser.parse(beanClass);
-			for (final BeanEntry entry : result.entries) {
-				Object value = null;
-				if (entry.isArray) {
-					value = Array.newInstance(entry.type, entry.arraySize);
-					for (int i = 0; i < entry.arraySize; i++) {
-						final Object component = entry.serializer.extract(entry.type, buffer,
-								entry.byteOffset + byteOffset + (i * entry.s7type.getByteSize()),
-								entry.bitOffset + (i * entry.s7type.getBitSize()));
-						Array.set(value, i, component);
-					}
-				} else {
-					value = entry.serializer.extract(entry.type, buffer, entry.byteOffset + byteOffset,
-							entry.bitOffset);
-				}
+        try {
+            final T obj = beanClass.newInstance();
+            final BeanParseResult result = BeanParser.parse(beanClass);
+            for (final BeanEntry entry : result.entries) {
+                Object value = null;
+                if (entry.isArray) {
+                    value = Array.newInstance(entry.type, entry.arraySize);
+                    for (int i = 0; i < entry.arraySize; i++) {
+                        final Object component = entry.serializer.extract(entry.type, buffer,
+                                entry.byteOffset + byteOffset + (i * entry.s7type.getByteSize()),
+                                entry.bitOffset + (i * entry.s7type.getBitSize()));
+                        Array.set(value, i, component);
+                    }
+                } else {
+                    value = entry.serializer.extract(entry.type, buffer, entry.byteOffset + byteOffset,
+                            entry.bitOffset);
+                }
 
-				if (entry.field.getType() == byte[].class){
-					//Special case issue #45
-					Byte[] oldValue = (Byte[])value;
+                if (entry.field.getType() == byte[].class) {
+                    //Special case issue #45
+                    Byte[] oldValue = (Byte[]) value;
 
-					value = new byte[oldValue.length];
+                    value = new byte[oldValue.length];
 
-					for (int i=0; i<oldValue.length; i++){
-						((byte[])value)[i] = oldValue[i];
-					}
-				}
+                    for (int i = 0; i < oldValue.length; i++) {
+                        ((byte[]) value)[i] = oldValue[i];
+                    }
+                }
 
-				entry.field.set(obj, value);
-			}
+                entry.field.set(obj, value);
+            }
 
-			return obj;
-		} catch (final Exception e) {
-			throw new S7Exception("extractBytes", e);
-		}
-	}
+            return obj;
+        } catch (final Exception e) {
+            throw new S7Exception("extractBytes", e);
+        }
+    }
 
-	/**
-	 * Inserts the bytes to the buffer.
-	 *
-	 * @param bean
-	 *            the bean
-	 * @param buffer
-	 *            the buffer
-	 * @param byteOffset
-	 *            the byte offset
-	 */
-	public static void insertBytes(final Object bean, final byte[] buffer, final int byteOffset) {
-		logger.trace("Inerting buffer with size: {} at offset {} into bean: {}", buffer.length, byteOffset, bean);
+    /**
+     * Inserts the bytes to the buffer.
+     *
+     * @param bean       the bean
+     * @param buffer     the buffer
+     * @param byteOffset the byte offset
+     */
+    public static void insertBytes(final Object bean, final byte[] buffer, final int byteOffset) {
+        logger.trace("Inerting buffer with size: {} at offset {} into bean: {}", buffer.length, byteOffset, bean);
 
-		try {
-			final BeanParseResult result = BeanParser.parse(bean);
+        try {
+            final BeanParseResult result = BeanParser.parse(bean);
 
-			for (final BeanEntry entry : result.entries) {
-				final Object fieldValue = entry.field.get(bean);
+            for (final BeanEntry entry : result.entries) {
+                final Object fieldValue = entry.field.get(bean);
 
-				if (fieldValue != null) {
-					if (entry.isArray) {
-						for (int i = 0; i < entry.arraySize; i++) {
-							final Object arrayItem = Array.get(fieldValue, i);
+                if (fieldValue != null) {
+                    if (entry.isArray) {
+                        for (int i = 0; i < entry.arraySize; i++) {
+                            final Object arrayItem = Array.get(fieldValue, i);
 
-							if (arrayItem != null) {
-								entry.serializer.insert(arrayItem, buffer,
-										entry.byteOffset + byteOffset + (i * entry.s7type.getByteSize()),
-										entry.bitOffset + (i * entry.s7type.getBitSize()), entry.size);
-							}
-						}
-					} else {
-						entry.serializer.insert(fieldValue, buffer, entry.byteOffset + byteOffset, entry.bitOffset,
-								entry.size);
-					}
-				}
-			}
-		} catch (final Exception e) {
-			throw new S7Exception("insertBytes", e);
-		}
-	}
+                            if (arrayItem != null) {
+                                entry.serializer.insert(arrayItem, buffer,
+                                        entry.byteOffset + byteOffset + (i * entry.s7type.getByteSize()),
+                                        entry.bitOffset + (i * entry.s7type.getBitSize()), entry.size);
+                            }
+                        }
+                    } else {
+                        entry.serializer.insert(fieldValue, buffer, entry.byteOffset + byteOffset, entry.bitOffset,
+                                entry.size);
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            throw new S7Exception("insertBytes", e);
+        }
+    }
 
-	/** The Connector. */
-	private final S7Connector connector;
+    /**
+     * The Connector.
+     */
+    private final S7Connector connector;
 
-	/**
-	 * Instantiates a new s7 serializer.
-	 *
-	 * @param connector
-	 *            the connector
-	 */
-	public S7SerializerImpl(final S7Connector connector) {
-		this.connector = connector;
-	}
+    /**
+     * Instantiates a new s7 serializer.
+     *
+     * @param connector the connector
+     */
+    public S7SerializerImpl(final S7Connector connector) {
+        this.connector = connector;
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public synchronized <T> T dispense(final Class<T> beanClass, final int dbNum, final int byteOffset)
-			throws S7Exception {
-		try {
-			final BeanParseResult result = BeanParser.parse(beanClass);
-			final byte[] buffer = this.connector.read(DaveArea.DB, dbNum, result.blockSize, byteOffset);
-			return extractBytes(beanClass, buffer, 0);
-		} catch (final Exception e) {
-			throw new S7Exception("dispense", e);
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized <T> T dispense(final Class<T> beanClass, final int dbNum, final int byteOffset)
+            throws S7Exception {
+        try {
+            final BeanParseResult result = BeanParser.parse(beanClass);
+            final byte[] buffer = this.connector.read(DaveArea.DB, dbNum, result.blockSize, byteOffset);
+            return extractBytes(beanClass, buffer, 0);
+        } catch (final Exception e) {
+            throw new S7Exception("dispense", e);
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public synchronized <T> T dispense(final Class<T> beanClass, final int dbNum, final int byteOffset,
-			final int blockSize) throws S7Exception {
-		try {
-			final byte[] buffer = this.connector.read(DaveArea.DB, dbNum, blockSize, byteOffset);
-			return extractBytes(beanClass, buffer, 0);
-		} catch (final Exception e) {
-			throw new S7Exception(
-					"dispense dbnum(" + dbNum + ") byteoffset(" + byteOffset + ") blocksize(" + blockSize + ")", e);
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized <T> T dispense(final Class<T> beanClass, final int dbNum, final int byteOffset,
+                                       final int blockSize) throws S7Exception {
+        try {
+            final byte[] buffer = this.connector.read(DaveArea.DB, dbNum, blockSize, byteOffset);
+            return extractBytes(beanClass, buffer, 0);
+        } catch (final Exception e) {
+            throw new S7Exception(
+                    "dispense dbnum(" + dbNum + ") byteoffset(" + byteOffset + ") blocksize(" + blockSize + ")", e);
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public synchronized void store(final Object bean, final int dbNum, final int byteOffset) {
-		try {
-			final BeanParseResult result = BeanParser.parse(bean);
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void store(final Object bean, final int dbNum, final int byteOffset) {
+        try {
+            final BeanParseResult result = BeanParser.parse(bean);
 
-			final byte[] buffer = new byte[result.blockSize];
-			logger.trace("store-buffer-size: " + buffer.length);
+            final byte[] buffer = new byte[result.blockSize];
+            logger.trace("store-buffer-size: {}", buffer.length);
 
-			insertBytes(bean, buffer, 0);
+            insertBytes(bean, buffer, 0);
 
-			this.connector.write(DaveArea.DB, dbNum, byteOffset, buffer);
-		} catch (final Exception e) {
-			throw new S7Exception("store", e);
-		}
-	}
+            this.connector.write(DaveArea.DB, dbNum, byteOffset, buffer);
+        } catch (final Exception e) {
+            throw new S7Exception("store", e);
+        }
+    }
 
 }

--- a/src/main/java/com/github/s7connector/impl/serializer/parser/BeanParser.java
+++ b/src/main/java/com/github/s7connector/impl/serializer/parser/BeanParser.java
@@ -15,141 +15,132 @@ limitations under the License.
 */
 package com.github.s7connector.impl.serializer.parser;
 
-import java.lang.reflect.Field;
-
+import com.github.s7connector.api.S7Serializable;
+import com.github.s7connector.api.S7Type;
+import com.github.s7connector.api.annotation.S7Variable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.s7connector.api.S7Serializable;
-import com.github.s7connector.api.annotation.S7Variable;
-import com.github.s7connector.api.S7Type;
+import java.lang.reflect.Field;
 
 public final class BeanParser {
+    private BeanParser() {
+    }
 
-	/**
-	 * Local Logger
-	 */
-	private static final Logger logger = LoggerFactory.getLogger(BeanParser.class);
+    /**
+     * Local Logger
+     */
+    private static final Logger logger = LoggerFactory.getLogger(BeanParser.class);
 
-	/**
-	 * Returns the wrapper for the primitive type
-	 * 
-	 * @param primitiveType
-	 * @return
-	 */
-	private static Class<?> getWrapperForPrimitiveType(final Class<?> primitiveType) {
-		if (primitiveType == boolean.class) {
-			return Boolean.class;
-		} else if (primitiveType == byte.class) {
-			return Byte.class;
-		} else if (primitiveType == int.class) {
-			return Integer.class;
-		} else if (primitiveType == float.class) {
-			return Float.class;
-		} else if (primitiveType == double.class) {
-			return Double.class;
-		} else if (primitiveType == long.class) {
-			return Long.class;
-		} else {
-			// Fallback
-			return primitiveType;
-		}
-	}
+    /**
+     * Returns the wrapper for the primitive type
+     */
+    private static Class<?> getWrapperForPrimitiveType(final Class<?> primitiveType) {
+        if (primitiveType == boolean.class) {
+            return Boolean.class;
+        } else if (primitiveType == byte.class) {
+            return Byte.class;
+        } else if (primitiveType == int.class) {
+            return Integer.class;
+        } else if (primitiveType == float.class) {
+            return Float.class;
+        } else if (primitiveType == double.class) {
+            return Double.class;
+        } else if (primitiveType == long.class) {
+            return Long.class;
+        } else {
+            // Fallback
+            return primitiveType;
+        }
+    }
 
-	/**
-	 * Parses a Class
-	 * 
-	 * @param jclass
-	 * @return
-	 * @throws Exception
-	 */
-	public static BeanParseResult parse(final Class<?> jclass) throws Exception {
-		final BeanParseResult res = new BeanParseResult();
-		logger.trace("Parsing: " + jclass.getName());
+    /**
+     * Parses a Class
+     */
+    public static BeanParseResult parse(final Class<?> jclass) throws Exception {
+        final BeanParseResult res = new BeanParseResult();
+        logger.trace("Parsing: {}", jclass.getName());
 
-		for (final Field field : jclass.getFields()) {
-			final S7Variable dataAnnotation = field.getAnnotation(S7Variable.class);
+        for (final Field field : jclass.getFields()) {
+            final S7Variable dataAnnotation = field.getAnnotation(S7Variable.class);
 
-			if (dataAnnotation != null) {
-				logger.trace("Parsing field: " + field.getName());
-				logger.trace("		type: " + dataAnnotation.type());
-				logger.trace("		byteOffset: " + dataAnnotation.byteOffset());
-				logger.trace("		bitOffset: " + dataAnnotation.bitOffset());
-				logger.trace("		size: " + dataAnnotation.size());
-				logger.trace("		arraySize: " + dataAnnotation.arraySize());
+            if (dataAnnotation != null) {
+                logger.trace("Parsing field: {}", field.getName());
+                logger.trace("\t\ttype: {}", dataAnnotation.type());
+                logger.trace("\t\tbyteOffset: {}", dataAnnotation.byteOffset());
+                logger.trace("\t\tbitOffset: {}", dataAnnotation.bitOffset());
+                logger.trace("\t\tsize: {}", dataAnnotation.size());
+                logger.trace("\t\tarraySize: {}", dataAnnotation.arraySize());
 
-				final int offset = dataAnnotation.byteOffset();
+                final int offset = dataAnnotation.byteOffset();
 
-				// update max offset
-				if (offset > res.blockSize) {
-					res.blockSize = offset;
-				}
+                // update max offset
+                if (offset > res.blockSize) {
+                    res.blockSize = offset;
+                }
 
-				if (dataAnnotation.type() == S7Type.STRUCT) {
-					// recurse
-					logger.trace("Recursing...");
-					final BeanParseResult subResult = parse(field.getType());
-					res.blockSize += subResult.blockSize;
-					logger.trace("	New blocksize: " + res.blockSize);
-				}
+                if (dataAnnotation.type() == S7Type.STRUCT) {
+                    // recurse
+                    logger.trace("Recursing...");
+                    final BeanParseResult subResult = parse(field.getType());
+                    res.blockSize += subResult.blockSize;
+                    logger.trace("\tNew blocksize: {}", res.blockSize);
+                }
 
-				logger.trace("	New blocksize (+offset): " + res.blockSize);
+                logger.trace("\tNew blocksize (+offset): {}", res.blockSize);
 
-				// Add dynamic size
-				res.blockSize += dataAnnotation.size();
+                // Add dynamic size
+                res.blockSize += dataAnnotation.size();
 
-				// Plain element
-				final BeanEntry entry = new BeanEntry();
-				entry.byteOffset = dataAnnotation.byteOffset();
-				entry.bitOffset = dataAnnotation.bitOffset();
-				entry.field = field;
-				entry.type = getWrapperForPrimitiveType(field.getType());
-				entry.size = dataAnnotation.size();
-				entry.s7type = dataAnnotation.type();
-				entry.isArray = field.getType().isArray();
-				entry.arraySize = dataAnnotation.arraySize();
+                // Plain element
+                final BeanEntry entry = new BeanEntry();
+                entry.byteOffset = dataAnnotation.byteOffset();
+                entry.bitOffset = dataAnnotation.bitOffset();
+                entry.field = field;
+                entry.type = getWrapperForPrimitiveType(field.getType());
+                entry.size = dataAnnotation.size();
+                entry.s7type = dataAnnotation.type();
+                entry.isArray = field.getType().isArray();
+                entry.arraySize = dataAnnotation.arraySize();
 
-				if (entry.isArray) {
-					entry.type = getWrapperForPrimitiveType(entry.type.getComponentType());
-				}
+                if (entry.isArray) {
+                    entry.type = getWrapperForPrimitiveType(entry.type.getComponentType());
+                }
 
-				// Create new serializer
-				final S7Serializable s = entry.s7type.getSerializer().newInstance();
-				entry.serializer = s;
+                // Create new serializer
+                final S7Serializable s = entry.s7type.getSerializer().newInstance();
+                entry.serializer = s;
 
-				res.blockSize += (s.getSizeInBytes() * dataAnnotation.arraySize());
-				logger.trace("	New blocksize (+array): " + res.blockSize);
+                res.blockSize += (s.getSizeInBytes() * dataAnnotation.arraySize());
+                logger.trace("\tNew blocksize (+array): {}", res.blockSize);
 
-				if (s.getSizeInBits() > 0) {
-					boolean offsetOfBitAlreadyKnown = false;
-					for (final BeanEntry parsedEntry : res.entries) {
-						if (parsedEntry.byteOffset == entry.byteOffset) {
-							offsetOfBitAlreadyKnown = true;
-						}
-					}
-					if (!offsetOfBitAlreadyKnown) {
-						res.blockSize++;
-					}
-				}
+                if (s.getSizeInBits() > 0) {
+                    boolean offsetOfBitAlreadyKnown = false;
+                    for (final BeanEntry parsedEntry : res.entries) {
+                        if (parsedEntry.byteOffset == entry.byteOffset) {
+                            offsetOfBitAlreadyKnown = true;
+                            break;
+                        }
+                    }
+                    if (!offsetOfBitAlreadyKnown) {
+                        res.blockSize++;
+                    }
+                }
 
-				res.entries.add(entry);
-			}
-		}
+                res.entries.add(entry);
+            }
+        }
 
-		logger.trace("Parsing done, overall size: " + res.blockSize);
+        logger.trace("Parsing done, overall size: {}", res.blockSize);
 
-		return res;
-	}
+        return res;
+    }
 
-	/**
-	 * Parses an Object
-	 * 
-	 * @param obj
-	 * @return
-	 * @throws Exception
-	 */
-	public static BeanParseResult parse(final Object obj) throws Exception {
-		return parse(obj.getClass());
-	}
+    /**
+     * Parses an Object
+     */
+    public static BeanParseResult parse(final Object obj) throws Exception {
+        return parse(obj.getClass());
+    }
 
 }

--- a/src/test/java/com/github/s7connector/test/SerializerStructArrayTest.java
+++ b/src/test/java/com/github/s7connector/test/SerializerStructArrayTest.java
@@ -1,0 +1,134 @@
+/*
+Copyright 2016 S7connector members (github.com/s7connector)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.github.s7connector.test;
+
+import com.github.s7connector.api.S7Serializer;
+import com.github.s7connector.api.S7Type;
+import com.github.s7connector.api.annotation.Datablock;
+import com.github.s7connector.api.annotation.S7Variable;
+import com.github.s7connector.api.factory.S7SerializerFactory;
+import com.github.s7connector.test.connector.EchoConnector;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class SerializerStructArrayTest {
+    private static final int SUBSTRUCTURE_REPETITION = 5;
+    private static final long EPOCH_YEAR2000_MILLIS = (2000 - 1970) * 365 * 24 * 60 * 60 * 1000L;
+
+    @Test
+    public void test() {
+        final EchoConnector c = new EchoConnector();
+
+        final S7Serializer p = S7SerializerFactory.buildSerializer(c);
+
+        // fixture
+        final StructDB in = new StructDB();
+        in.byte1 = 0x01;
+        in.byteArray[0] = 0;
+        in.byteArray[1] = 1;
+        in.byteArray[2] = 2;
+        in.subStruct = new SubStruct[SUBSTRUCTURE_REPETITION];
+        for (int i = 0; i < SUBSTRUCTURE_REPETITION; ++i) {
+            in.subStruct[i] = new SubStruct();
+            in.subStruct[i].subByte = (byte) (10 + i);
+        }
+
+        // execute test
+        p.store(in, 0, 0);
+        Assert.assertEquals(
+                Arrays.asList((byte) 1, (byte) 0, (byte) 1, (byte) 2, (byte) 10, (byte) 11, (byte) 12, (byte) 13, (byte) 14),
+                IntStream.range(0, c.buffer.length).mapToObj(i -> c.buffer[i]).collect(Collectors.toList()));
+
+        // check results
+        final StructDB out = p.dispense(StructDB.class, 0, 0);
+        Assert.assertEquals(in.byte1, out.byte1);
+        Assert.assertArrayEquals(in.byteArray, out.byteArray);
+        Assert.assertEquals(in.subStruct.length, out.subStruct.length);
+        for (int i = 0; i < SUBSTRUCTURE_REPETITION; ++i) {
+            Assert.assertEquals("subStruct[" + i + "]", in.subStruct[i].subByte, out.subStruct[i].subByte);
+        }
+
+        // execute same test on same connector instance
+        testTopLevelArrayStruct(p);
+    }
+
+    private void testTopLevelArrayStruct(S7Serializer p) {
+        final ArrayStructDB in = new ArrayStructDB();
+        in.listOfStruct = new ArraySubStruct[3];
+        in.listOfStruct[0] = new ArraySubStruct("txt0", new Date(1_000_000 + EPOCH_YEAR2000_MILLIS));
+        in.listOfStruct[1] = new ArraySubStruct("txt1", new Date(2_000_000 + EPOCH_YEAR2000_MILLIS));
+        in.listOfStruct[2] = new ArraySubStruct("txt2", new Date(3_000_000 + EPOCH_YEAR2000_MILLIS));
+        p.store(in, 0, 0);
+        final ArrayStructDB out = p.dispense(ArrayStructDB.class, 0, 0);
+        Assert.assertEquals(in.listOfStruct.length, out.listOfStruct.length);
+        for (int i = 0; i < in.listOfStruct.length; ++i) {
+            Assert.assertEquals(in.listOfStruct[i].str, out.listOfStruct[i].str);
+            Assert.assertEquals(in.listOfStruct[i].date, out.listOfStruct[i].date);
+        }
+    }
+
+    @Test
+    public void testTopLevelArrayStruct() {
+        testTopLevelArrayStruct(S7SerializerFactory.buildSerializer(new EchoConnector()));
+    }
+
+    @Datablock
+    public static class StructDB {
+        @S7Variable(type = S7Type.BYTE, byteOffset = 0)
+        public byte byte1;
+
+        /**
+         * Initialized array
+         */
+        @S7Variable(type = S7Type.BYTE, byteOffset = 1, arraySize = 3)
+        public byte[] byteArray = new byte[3];
+
+        @S7Variable(type = S7Type.STRUCT, byteOffset = 1 + 3, arraySize = SUBSTRUCTURE_REPETITION)
+        public SubStruct[] subStruct;
+    }
+
+    public static class SubStruct {
+        @S7Variable(type = S7Type.BYTE, byteOffset = 0)
+        public byte subByte;
+    }
+
+    @Datablock
+    public static class ArrayStructDB {
+        @S7Variable(type = S7Type.STRUCT, arraySize = 3, byteOffset = 0)
+        public ArraySubStruct[] listOfStruct;
+    }
+
+    public static class ArraySubStruct {
+        @S7Variable(type = S7Type.STRING, size = 4, byteOffset = 0)
+        public String str;
+        // note: String has 2 bytes overhead (for max length and actual length)
+        @S7Variable(type = S7Type.DATE_AND_TIME, byteOffset = 4 + 2)
+        public Date date;
+
+        public ArraySubStruct() {
+        }
+
+        public ArraySubStruct(String s, Date d) {
+            str = s;
+            date = d;
+        }
+    }
+}


### PR DESCRIPTION
Using dataAnnotation.size() value to store blockSize of STRUCT from recursion, applied conservatively.
Unittests added for this scenario.

Sorry, seems like my IntelliJ made-up the format of the source file.
